### PR TITLE
Prevent duplicate triggers from being added

### DIFF
--- a/CacheStack/CacheExtensions.cs
+++ b/CacheStack/CacheExtensions.cs
@@ -9,7 +9,7 @@ namespace CacheStack
 	public static class CacheExtensions
 	{
 		private static readonly ConcurrentDictionary<string, List<string>> Triggers = new ConcurrentDictionary<string, List<string>>();
-		
+
 		/// <summary>
 		/// Trigger a notification to clear the cache for items that are watching the specified <c>ICacheTrigger</c>
 		/// </summary>
@@ -139,7 +139,7 @@ namespace CacheStack
 			foreach (var watch in context.TriggerWatchers)
 			{
 				var keys = Triggers.GetOrAdd(watch.Name, new List<string>());
-				keys.Add(key);
+				AddUniqueKey(keys, key);
 			}
 		}
 
@@ -163,6 +163,15 @@ namespace CacheStack
 				cache.CacheAndSetTriggers(context, key, item);
 			}
 			return item.Value;
+		}
+		
+		/// <summary>
+		/// Clear all triggers
+		/// </summary>
+		/// <param name="cache">Cache to work with</param>
+		public static void FlushTriggers(this ICacheClient cache)
+		{
+			Triggers.Clear();
 		}
 	}
 }


### PR DESCRIPTION
Triggers were indeed being added more than once. You already had a function to handle that so I utilized it. Also added a FlushTriggers() extensions since you could do a cache.FlushAll() but leave all of your triggers orphaned. Not sure if that is really a problem, but can't hurt much to add. It would be good to hook it into the MemoryCacheClient.FlushAll() method so that you don't even have to think about it. Can't do that until this is merged though.
